### PR TITLE
Implementing new tests folder structure, acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ if you've set up [global install](https://phpunit.de/manual/current/en/installat
 
 To run tests with code coverage, run `phpunit --coverage-text`.
 
+To run acceptance (end-to-end) tests with your API credentials, run `PARTNER_ID=XXX PARTNER_KEY=YYYYY phpunit`.
+
 If you're green, you're good!
 
 ## Actions

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,9 @@
   <filter>
     <whitelist>
       <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/Error</directory>
+      </exclude>
     </whitelist>
   </filter>
 </phpunit>

--- a/src/Action/Company.php
+++ b/src/Action/Company.php
@@ -138,8 +138,8 @@ class Company implements ActionInterface {
    * Build the Response Object
    *
    * @param array $body
-   * @param \Psr\Http\Message\ResponseInterface $response
-   * @return \Glassdoor\ResponseObject\ResponseInterface
+   * @param \GuzzleHttp\Psr7\Response $response
+   * @return \Glassdoor\ResponseObject\Company\CompanyResponse
    */
   public function buildResponse(array $body, Response $response) {
     $companies = empty($body['response']['employers']) ? [] : $body['response']['employers'];

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -5,5 +5,10 @@ namespace Glassdoor\Tests\Action;
 use Glassdoor\Action\Company;
 
 class CompanyTest extends \PHPUnit_Framework_TestCase {
-  // Tests go here
+  
+    public function testItCanInstantiate()
+    {
+        $company = new Company();
+    }
+
 }

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -6,9 +6,21 @@ use Glassdoor\Action\Company;
 
 class CompanyTest extends \PHPUnit_Framework_TestCase {
   
-    public function testItCanInstantiate()
+    public function setUp()
     {
-        $company = new Company();
+        $this->company = new Company();
+    }
+
+    public function testItCanBuildResponse()
+    {
+        $body = [
+            'response' => null,
+        ];
+        $response = new \GuzzleHttp\Psr7\Response;
+
+        $result = $this->company->buildResponse($body, $response);
+
+        $this->assertEquals('Glassdoor\ResponseObject\Company\CompanyResponse', get_class($result));
     }
 
 }

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Glassdoor\Tests\Action;
+
+use Glassdoor\Action\Company;
+
+class CompanyTest extends \PHPUnit_Framework_TestCase {
+  // Tests go here
+}

--- a/tests/Action/JobProgressionTest.php
+++ b/tests/Action/JobProgressionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Glassdoor\Tests;
+namespace Glassdoor\Tests\Action;
 
 use Glassdoor\Action\JobProgression;
 use Glassdoor\Tests\Fixture\JobProgression as JobProgressionFixture;

--- a/tests/CompanyAcceptanceTest.php
+++ b/tests/CompanyAcceptanceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Action\Company;
+use Glassdoor\Config;
+use Glassdoor\Connection;
+
+class CompanyAcceptanceTest extends \PHPUnit_Framework_TestCase {
+  
+    /* 
+     * Company Acceptance test 
+     * Ensures the API client works end-to-end
+     */
+    public function testItCanGetCompanyFromApiInRealLife()
+    {
+        // Check for and set required server variables
+        if (!isset($_SERVER['PARTNER_ID'])) {
+            $this->markTestSkipped('PARTNER_ID is not available');
+        }
+        if (!isset($_SERVER['PARTNER_KEY'])) {
+            $this->markTestSkipped('PARTNER_KEY is not available');
+        }
+        $_SERVER['REMOTE_ADDR'] = getHostByName(getHostName());
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+
+        // Instantiate the connection
+        $config = new Config($_SERVER['PARTNER_ID'], $_SERVER['PARTNER_KEY']);
+        $connection = new Connection($config);
+
+        $action = new Company;
+        $action->addparam('query', 'google');
+
+        // Get the response from the API
+        $response = $connection->call($action);
+        
+        // Assert proper classes/results are returned
+        $this->assertEquals('Glassdoor\ResponseObject\Company\CompanyResponse', get_class($response));
+        foreach ($response->getCompanies() as $company) {
+            $this->assertEquals('Glassdoor\ResponseObject\Company\Company', get_class($company));
+            $this->assertNotNull($company->getId());
+        }
+    }
+
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -2,8 +2,22 @@
 
 namespace Glassdoor\Tests;
 
+use Glassdoor\Config;
 use Glassdoor\Connection;
 
 class ConnectionTest extends \PHPUnit_Framework_TestCase {
-  // Tests go here
+  
+    public function testItCanInstantiate()
+    {
+        $partner_id = 123;
+        $partner_key = 1234;
+        $base_url = 'http://google.com';
+        $config = new Config($partner_id, $partner_key, $base_url, 'json');
+        
+        // Mocking the config would be better, but this one's marked final
+        // $config = $this->getMockBuilder('Glassdoor\Config')->getMock();
+        
+        $connection = new Connection($config);
+    }
+
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Connection;
+
+class ConnectionTest extends \PHPUnit_Framework_TestCase {
+  // Tests go here
+}

--- a/tests/JobProgressionAcceptanceTest.php
+++ b/tests/JobProgressionAcceptanceTest.php
@@ -9,10 +9,10 @@ use Glassdoor\Connection;
 class JobProgressionAcceptanceTest extends \PHPUnit_Framework_TestCase {
   
     /* 
-     * Company Acceptance test 
+     * JobProgression Acceptance test 
      * Ensures the API client works end-to-end
      */
-    public function testItCanGetCompanyFromApiInRealLife()
+    public function testItCanGetJobProgressionFromApiInRealLife()
     {
         // Check for and set required server variables
         if (!isset($_SERVER['PARTNER_ID'])) {

--- a/tests/JobProgressionAcceptanceTest.php
+++ b/tests/JobProgressionAcceptanceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Action\JobProgression;
+use Glassdoor\Config;
+use Glassdoor\Connection;
+
+class JobProgressionAcceptanceTest extends \PHPUnit_Framework_TestCase {
+  
+    /* 
+     * Company Acceptance test 
+     * Ensures the API client works end-to-end
+     */
+    public function testItCanGetCompanyFromApiInRealLife()
+    {
+        // Check for and set required server variables
+        if (!isset($_SERVER['PARTNER_ID'])) {
+            $this->markTestSkipped('PARTNER_ID is not available');
+        }
+        if (!isset($_SERVER['PARTNER_KEY'])) {
+            $this->markTestSkipped('PARTNER_KEY is not available');
+        }
+        $_SERVER['REMOTE_ADDR'] = getHostByName(getHostName());
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+
+        // Instantiate the connection
+        $config = new Config($_SERVER['PARTNER_ID'], $_SERVER['PARTNER_KEY']);
+        $connection = new Connection($config);
+
+        $action = new JobProgression;
+        $action->addparam('job_title', 'developer');
+
+        // Get the response from the API
+        $response = $connection->call($action);
+        
+        // Assert proper classes/results are returned
+        $this->assertEquals('Glassdoor\ResponseObject\JobProgressionResponse', get_class($response));
+        foreach ($response->getJobProgressions() as $progression) {
+            $this->assertEquals('Glassdoor\ResponseObject\JobProgression', get_class($progression));
+            $this->assertNotNull($progression->getJobTitle());
+        }
+    }
+
+}

--- a/tests/ResponseObject/Company/PersonTest.php
+++ b/tests/ResponseObject/Company/PersonTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Glassdoor\Tests\ResponseObject\Company;
+
+use Glassdoor\ResponseObject\Company\Person;
+
+class PersonTest extends \PHPUnit_Framework_TestCase {
+    
+    public function setUp()
+    {
+        $this->values = [
+            'name' => uniqid(),
+            'title' => uniqid(),
+            'percent_approval' => uniqid(),
+            'percent_disapproval' => uniqid(),
+            'image' => [
+                'src' => uniqid(),
+                'height' => uniqid(),
+                'width' => uniqid(),
+            ],
+        ];
+
+        $this->person = new Person($this->values);
+    }
+
+    public function testItCanInstantiateWithoutImage()
+    {
+        $values = $this->values;
+        $values['image'] = [];
+
+        $person = new Person($values);
+    }
+
+    public function testItGetsPersonName()
+    {
+        $result = $this->person->getName();
+        
+        $this->assertEquals($this->values['name'], $result);
+    }
+
+    public function testItGetsPersonTitle()
+    {
+        $result = $this->person->getTitle();
+        
+        $this->assertEquals($this->values['title'], $result);
+    }
+
+    public function testItGetsPersonPercentApproval()
+    {
+        $result = $this->person->getPercentApproval();
+        
+        $this->assertEquals($this->values['percent_approval'], $result);
+    }
+
+    public function testItGetsPersonPercentDisapproval()
+    {
+        $result = $this->person->getPercentDisapproval();
+        
+        $this->assertEquals($this->values['percent_disapproval'], $result);
+    }
+
+    public function testItGetsPersonImage()
+    {   
+        $result = $this->person->getImage();
+        
+        $this->assertEquals('Glassdoor\ResponseObject\Image', get_class($result));
+    }
+    
+}

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Glassdoor\Tests\ResponseObject;
+
+use Glassdoor\ResponseObject\Image;
+
+class ImageTest extends \PHPUnit_Framework_TestCase {
+    
+    public function setUp()
+    {
+        $this->values = [
+            'src' => uniqid(),
+            'height' => uniqid(),
+            'width' => uniqid(),
+            'weight' => uniqid(),
+        ];
+
+        $this->image = new Image($this->values);
+    }
+
+    /**
+     * @expectedException \Glassdoor\Error\GlassDoorResponseException
+     * @expectedExceptionMessage Image requires src, height and width
+     */
+    public function testItThrowsErrorWhenInvalidInputValues()
+    {
+        $values = [];
+        $image = new Image($values);
+    }
+
+    public function testItGetsImageSrc()
+    {
+        $result = $this->image->getSrc();
+        
+        $this->assertEquals($this->values['src'], $result);
+    }
+
+    public function testItGetsImageHeight()
+    {
+        $result = $this->image->getHeight();
+        
+        $this->assertEquals($this->values['height'], $result);
+    }
+
+    public function testItGetsImageWeight()
+    {
+        $result = $this->image->getWeight();
+        
+        $this->assertEquals($this->values['weight'], $result);
+    }
+    
+}

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -44,9 +44,9 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
 
     public function testItGetsImageWeight()
     {
-        $result = $this->image->getWeight();
-        
-        $this->assertEquals($this->values['weight'], $result);
+        // Not working, might be a bug.
+        // $result = $this->image->getWeight();
+        // $this->assertEquals($this->values['weight'], $result);
     }
     
 }

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -12,7 +12,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
             'src' => uniqid(),
             'height' => uniqid(),
             'width' => uniqid(),
-            'weight' => uniqid(),
         ];
 
         $this->image = new Image($this->values);
@@ -42,11 +41,10 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($this->values['height'], $result);
     }
 
-    public function testItGetsImageWeight()
+    public function testItGetsImageWidth()
     {
-        // Not working, might be a bug.
-        // $result = $this->image->getWeight();
-        // $this->assertEquals($this->values['weight'], $result);
+        $result = $this->image->getWidth();
+        $this->assertEquals($this->values['width'], $result);
     }
     
 }


### PR DESCRIPTION
As promised in #7 I've started working on tests here. I implemented a new folder structure for the tests that more closely mirrors the folder structure used in src. This helps us see which classes have coverage and which don't.

I also added two acceptance tests, which won't run in Travis, but you can run them from your command line using:

```
PARTNER_ID=XXX PARTNER_KEY=YYYYY phpunit
```

With your real Glassdoor credentials. I think this is a good check to make sure everything is working until we have more complete unit test coverage in place.

Let me know what you think!