### PR TITLE
Adding code sniffer with Drupal linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - travis_retry phpenv rehash
 
 script:
+  - ./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal src/
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - travis_retry phpenv rehash
 
 script:
-  - ./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal src/
+  - ./vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && ./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal src/
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ To run acceptance (end-to-end) tests with your API credentials, run `PARTNER_ID=
 
 If you're green, you're good!
 
+## Code Standards
+We are using [Drupal's Code Standards](https://www.drupal.org/coding-standards) 
+and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to test for them.
+
+Run the code sniffer using `./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal src/`
+
 ## Actions
 
 Implemented Endpoinsts:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ if you've set up [global install](https://phpunit.de/manual/current/en/installat
 
 To run tests with code coverage, run `phpunit --coverage-text`.
 
+To run acceptance (end-to-end) tests with your API credentials, run `PARTNER_ID=XXX PARTNER_KEY=YYYYY phpunit`.
+
 If you're green, you're good!
 
 ## Actions

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,13 @@
             "email": "neil.hastings@gmail.com"
         }
     ],
-    "require-dev": {
-        "phpunit/phpunit": "~4.0"
-    },
     "require": {
         "guzzlehttp/guzzle": "~6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0",
+        "squizlabs/php_codesniffer": "*",
+        "drupal/coder": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,9 @@
   <filter>
     <whitelist>
       <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/Error</directory>
+      </exclude>
     </whitelist>
   </filter>
 </phpunit>

--- a/src/Action/ActionInterface.php
+++ b/src/Action/ActionInterface.php
@@ -1,16 +1,22 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Action;
 
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\ResponseInterface;
-
+/**
+ *
+ */
 interface ActionInterface {
   /**
    * Set a url param.
    *
    * @param $key
    * @param $value
+   *
    * @return $this
    */
   public function addParam($key, $value);
@@ -23,14 +29,14 @@ interface ActionInterface {
   public static function action();
 
   /**
-   * The URL query parameters
+   * The URL query parameters.
    *
    * @return array
    */
   public function getParams();
 
   /**
-   * The HTTP method to use for the call
+   * The HTTP method to use for the call.
    *
    * @return string
    */
@@ -44,11 +50,13 @@ interface ActionInterface {
   public function getVersion();
 
   /**
-   * Build the Response Object
+   * Build the Response Object.
    *
    * @param array $body
    * @param \GuzzleHttp\Psr7\Response $response
+   *
    * @return \GuzzleHttp\Psr7\Response
    */
   public function buildResponse(array $body, Response $response);
+
 }

--- a/src/Action/Company.php
+++ b/src/Action/Company.php
@@ -1,13 +1,18 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Action;
 
 
 use Glassdoor\Error\GlassdoorException;
 use Glassdoor\ResponseObject\Company\CompanyResponse;
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\ResponseInterface;
-
+/**
+ *
+ */
 class Company implements ActionInterface {
   private $query;
   private $location_search;
@@ -18,6 +23,9 @@ class Company implements ActionInterface {
   private $page_size = 20;
 
 
+  /**
+   *
+   */
   public static function params() {
     return [
       'query',
@@ -30,22 +38,37 @@ class Company implements ActionInterface {
     ];
   }
 
+  /**
+   *
+   */
   public function filterByState($state) {
     return $this->addParam('state', $state);
   }
 
+  /**
+   *
+   */
   public function filterByCity($city) {
     return $this->addParam('city', $city);
   }
 
+  /**
+   *
+   */
   public function filterByCountry($country) {
     return $this->addParam('country', $country);
   }
 
+  /**
+   *
+   */
   public function searchByLocation($location) {
     return $this->addParam('location_search', $location);
   }
 
+  /**
+   *
+   */
   public function searchByCompanyOrJob($search) {
     return $this->addParam('queyr', $search);
   }
@@ -79,7 +102,7 @@ class Company implements ActionInterface {
   }
 
   /**
-   * The URL query parameters
+   * The URL query parameters.
    *
    * @return array
    */
@@ -117,7 +140,7 @@ class Company implements ActionInterface {
   }
 
   /**
-   * The HTTP method to use for the call
+   * The HTTP method to use for the call.
    *
    * @return string
    */
@@ -135,10 +158,11 @@ class Company implements ActionInterface {
   }
 
   /**
-   * Build the Response Object
+   * Build the Response Object.
    *
    * @param array $body
    * @param \GuzzleHttp\Psr7\Response $response
+   *
    * @return \Glassdoor\ResponseObject\Company\CompanyResponse
    */
   public function buildResponse(array $body, Response $response) {
@@ -155,4 +179,5 @@ class Company implements ActionInterface {
     $return = new CompanyResponse($values, $response);
     return $return;
   }
+
 }

--- a/src/Action/Company.php
+++ b/src/Action/Company.php
@@ -138,8 +138,8 @@ class Company implements ActionInterface {
    * Build the Response Object
    *
    * @param array $body
-   * @param \Psr\Http\Message\ResponseInterface $response
-   * @return \Glassdoor\ResponseObject\ResponseInterface
+   * @param \GuzzleHttp\Psr7\Response $response
+   * @return \Glassdoor\ResponseObject\Company\CompanyResponse
    */
   public function buildResponse(array $body, Response $response) {
     $companies = empty($body['response']['employers']) ? [] : $body['response']['employers'];

--- a/src/Action/JobProgression.php
+++ b/src/Action/JobProgression.php
@@ -1,13 +1,18 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Action;
 
 
 use Glassdoor\Error\GlassdoorException;
 use Glassdoor\ResponseObject\JobProgressionResponse;
-use Glassdoor\ResponseObject\ResponseInterface;
 use GuzzleHttp\Psr7\Response;
-
+/**
+ *
+ */
 class JobProgression implements ActionInterface {
   private $job_title;
   private $country_id = 1;
@@ -26,7 +31,7 @@ class JobProgression implements ActionInterface {
 
     return [
       'jobTitle' => $this->job_title,
-      'countryId' => $this->country_id
+      'countryId' => $this->country_id,
     ];
   }
 
@@ -36,6 +41,7 @@ class JobProgression implements ActionInterface {
    *
    * @param $key
    * @param $value
+   *
    * @return $this
    *
    * @throws \Glassdoor\Error\GlassdoorException
@@ -60,7 +66,7 @@ class JobProgression implements ActionInterface {
   }
 
   /**
-   * The HTTP method to use for the call
+   * The HTTP method to use for the call.
    *
    * @return string
    */
@@ -78,16 +84,17 @@ class JobProgression implements ActionInterface {
   }
 
   /**
-   * Build the Response Object
+   * Build the Response Object.
    *
    * @param array $body
    * @param \GuzzleHttp\Psr7\Response $response
+   *
    * @return \Glassdoor\ResponseObject\ResponseInterface
    */
   public function buildResponse(array $body, Response $response) {
     $progressions = empty($body['response']['results']) ? [] : $body['response']['results'];
 
-    // Clone the array
+    // Clone the array.
     $values = $body['response'];
     unset($values['result']);
 
@@ -95,4 +102,5 @@ class JobProgression implements ActionInterface {
 
     return new JobProgressionResponse($values, $response);
   }
+
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,10 +1,14 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor;
 use Glassdoor\Error\GlassDoorConfigException;
 
 /**
- * Configuration Class
+ * Configuration Class.
  */
 final class Config {
   /**
@@ -31,7 +35,7 @@ final class Config {
    * @param $response_format
    * @throws \Glassdoor\Error\GlassDoorConfigException
    */
-  public function __construct($partner_id, $partner_key, $base_url='http://api.glassdoor.com/api/api.htm', $response_format='json') {
+  public function __construct($partner_id, $partner_key, $base_url = 'http://api.glassdoor.com/api/api.htm', $response_format = 'json') {
     if (empty(trim($partner_id)) ||
         empty(trim($partner_key)) ||
         empty(trim($base_url))) {
@@ -81,4 +85,5 @@ final class Config {
   public function getPartnerKey() {
     return $this->partner_key;
   }
+
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor;
 use Glassdoor\Action\ActionInterface;
 use Glassdoor\Error\GlassDoorResponseException;
@@ -9,7 +13,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 
 /**
- * Makes the calls to Glassdoor
+ * Makes the calls to Glassdoor.
  */
 final class Connection {
   /**
@@ -28,14 +32,18 @@ final class Connection {
     $this->config = $config;
   }
 
+  /**
+   *
+   */
   public function setHandlerStack(HandlerStack $stack) {
     $this->stack = $stack;
   }
 
   /**
-   * Build a URI object for the Request
+   * Build a URI object for the Request.
    *
    * @param \Glassdoor\Action\ActionInterface $action
+   *
    * @return \GuzzleHttp\Psr7\Uri
    */
   private function buildUri(ActionInterface $action) {
@@ -50,7 +58,7 @@ final class Connection {
     $params['useragent'] = $_SERVER['HTTP_USER_AGENT'];
     $params['action'] = $action->action();
 
-    // Allow any overrides
+    // Allow any overrides.
     if (!empty($parts['query'])) {
       parse_str($parts['query'], $query_params);
       array_merge($params, $query_params);
@@ -62,15 +70,16 @@ final class Connection {
   }
 
   /**
-   * Make a call to the GlassDoor API
+   * Make a call to the GlassDoor API.
    *
    * @param \Glassdoor\Action\ActionInterface $action
+   *
    * @return \Glassdoor\ResponseObject\ResponseInterface
    *
    * @throws \Glassdoor\Error\GlassDoorResponseException
    */
   public function call(ActionInterface $action) {
-    // If a handler is set then use that to build the client
+    // If a handler is set then use that to build the client.
     if ($this->stack) {
       $client = new Client([
         'handler' => $this->stack,
@@ -102,4 +111,5 @@ final class Connection {
 
     return $action->buildResponse($body, $response);
   }
+
 }

--- a/src/Error/GlassDoorConfigException.php
+++ b/src/Error/GlassDoorConfigException.php
@@ -1,6 +1,11 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Error;
-
-
+/**
+ *
+ */
 class GlassDoorConfigException extends GlassdoorException {}

--- a/src/Error/GlassDoorResponseException.php
+++ b/src/Error/GlassDoorResponseException.php
@@ -1,8 +1,13 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Error;
-
-
+/**
+ *
+ */
 class GlassDoorResponseException extends GlassdoorException {
 
 }

--- a/src/Error/GlassdoorException.php
+++ b/src/Error/GlassdoorException.php
@@ -1,6 +1,11 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\Error;
-
-
+/**
+ *
+ */
 class GlassdoorException extends \Exception {}

--- a/src/ResponseObject/Company/Company.php
+++ b/src/ResponseObject/Company/Company.php
@@ -1,11 +1,16 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject\Company;
 
 
-use Glassdoor\ResponseObject\ResponseInterface;
 use GuzzleHttp\Psr7\Uri;
-
+/**
+ *
+ */
 class Company {
 
   /**
@@ -81,6 +86,9 @@ class Company {
    */
   private $ceo;
 
+  /**
+   *
+   */
   public function __construct(array $values) {
     $this->id = empty($values['id']) ? '' : $values['id'];
     $this->name = empty($values['name']) ? '' : $values['name'];
@@ -233,4 +241,5 @@ class Company {
   public function getCeo() {
     return $this->ceo;
   }
+
 }

--- a/src/ResponseObject/Company/CompanyResponse.php
+++ b/src/ResponseObject/Company/CompanyResponse.php
@@ -1,12 +1,18 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject\Company;
 
 
 use Glassdoor\ResponseObject\ResponseInterface;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
-
+/**
+ *
+ */
 class CompanyResponse implements ResponseInterface {
   /**
    * @var Uri
@@ -54,6 +60,9 @@ class CompanyResponse implements ResponseInterface {
    */
   private $response;
 
+  /**
+   *
+   */
   public function __construct(array $values, Response $response) {
     $this->response = $response;
 
@@ -69,7 +78,7 @@ class CompanyResponse implements ResponseInterface {
 
     $this->companies = [];
     if (!empty($values['companies']) && is_array($values['companies'])) {
-      foreach($values['companies'] as $company) {
+      foreach ($values['companies'] as $company) {
         $this->companies[] = new Company($company);
       }
     }
@@ -147,11 +156,12 @@ class CompanyResponse implements ResponseInterface {
   }
 
   /**
-   * The Guzzle response
+   * The Guzzle response.
    *
    * @return Response
    */
   public function getResponse() {
     return $this->response;
   }
+
 }

--- a/src/ResponseObject/Company/Person.php
+++ b/src/ResponseObject/Company/Person.php
@@ -1,11 +1,16 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject\Company;
 
 
 use Glassdoor\ResponseObject\Image;
-use Glassdoor\ResponseObject\ResponseInterface;
-
+/**
+ *
+ */
 class Person {
   /**
    * @var string
@@ -28,6 +33,9 @@ class Person {
    */
   private $image;
 
+  /**
+   *
+   */
   public function __construct(array $values) {
     $this->name = empty($values['name']) ? '' : $values['name'];
     $this->title = empty($values['title']) ? '' : $values['title'];

--- a/src/ResponseObject/Company/Review.php
+++ b/src/ResponseObject/Company/Review.php
@@ -1,10 +1,13 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject\Company;
-
-
-use Glassdoor\ResponseObject\ResponseInterface;
-
+/**
+ *
+ */
 class Review {
   /**
    * @var int
@@ -154,4 +157,5 @@ class Review {
   public function getOverallNumeric() {
     return $this->overallNumeric;
   }
+
 }

--- a/src/ResponseObject/Image.php
+++ b/src/ResponseObject/Image.php
@@ -1,10 +1,16 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject;
 
 
 use Glassdoor\Error\GlassDoorResponseException;
-
+/**
+ *
+ */
 class Image {
   /**
    * @var string

--- a/src/ResponseObject/JobProgression.php
+++ b/src/ResponseObject/JobProgression.php
@@ -1,8 +1,13 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject;
-
-
+/**
+ *
+ */
 class JobProgression {
   /**
    * @var string
@@ -26,6 +31,9 @@ class JobProgression {
   private $median_salary;
 
 
+  /**
+   *
+   */
   public function __construct(array $values) {
     $this->frequency = empty($value['frequency']) ? '' : $value['frequency'];
     $this->job_title = empty($value['nextJobTitle']) ? '' : $value['nextJobTitle'];

--- a/src/ResponseObject/JobProgressionResponse.php
+++ b/src/ResponseObject/JobProgressionResponse.php
@@ -1,10 +1,16 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject;
 
 
 use GuzzleHttp\Psr7\Response;
-
+/**
+ *
+ */
 class JobProgressionResponse implements ResponseInterface {
   /**
    * @var string
@@ -40,6 +46,9 @@ class JobProgressionResponse implements ResponseInterface {
    */
   private $response;
 
+  /**
+   *
+   */
   public function __construct(array $values, Response $response) {
     $this->response = $response;
 
@@ -52,7 +61,7 @@ class JobProgressionResponse implements ResponseInterface {
 
     $this->job_progressions = [];
     if (!empty($values['progressions']) && is_array($values['progressions'])) {
-      foreach($values['progressions'] as $progression) {
+      foreach ($values['progressions'] as $progression) {
         $this->job_progressions[] = new JobProgression($progression);
       }
     }
@@ -113,4 +122,5 @@ class JobProgressionResponse implements ResponseInterface {
   public function getResponse() {
     return $this->response;
   }
+
 }

--- a/src/ResponseObject/ResponseInterface.php
+++ b/src/ResponseObject/ResponseInterface.php
@@ -1,14 +1,21 @@
 <?php
 
+/**
+ * @file
+ */
+
 namespace Glassdoor\ResponseObject;
 
 
 use GuzzleHttp\Psr7\Response;
-
+/**
+ *
+ */
 interface ResponseInterface {
   /**
    * @param array $values
    * @param \GuzzleHttp\Psr7\Response $response
    */
   public function __construct(array $values, Response $response);
+
 }

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -5,5 +5,10 @@ namespace Glassdoor\Tests\Action;
 use Glassdoor\Action\Company;
 
 class CompanyTest extends \PHPUnit_Framework_TestCase {
-  // Tests go here
+  
+    public function testItCanInstantiate()
+    {
+        $company = new Company();
+    }
+
 }

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -6,9 +6,21 @@ use Glassdoor\Action\Company;
 
 class CompanyTest extends \PHPUnit_Framework_TestCase {
   
-    public function testItCanInstantiate()
+    public function setUp()
     {
-        $company = new Company();
+        $this->company = new Company();
+    }
+
+    public function testItCanBuildResponse()
+    {
+        $body = [
+            'response' => null,
+        ];
+        $response = new \GuzzleHttp\Psr7\Response;
+
+        $result = $this->company->buildResponse($body, $response);
+
+        $this->assertEquals('Glassdoor\ResponseObject\Company\CompanyResponse', get_class($result));
     }
 
 }

--- a/tests/Action/CompanyTest.php
+++ b/tests/Action/CompanyTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Glassdoor\Tests\Action;
+
+use Glassdoor\Action\Company;
+
+class CompanyTest extends \PHPUnit_Framework_TestCase {
+  // Tests go here
+}

--- a/tests/Action/JobProgressionTest.php
+++ b/tests/Action/JobProgressionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Glassdoor\Tests;
+namespace Glassdoor\Tests\Action;
 
 use Glassdoor\Action\JobProgression;
 use Glassdoor\Tests\Fixture\JobProgression as JobProgressionFixture;

--- a/tests/CompanyAcceptanceTest.php
+++ b/tests/CompanyAcceptanceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Action\Company;
+use Glassdoor\Config;
+use Glassdoor\Connection;
+
+class CompanyAcceptanceTest extends \PHPUnit_Framework_TestCase {
+  
+    /* 
+     * Company Acceptance test 
+     * Ensures the API client works end-to-end
+     */
+    public function testItCanGetCompanyFromApiInRealLife()
+    {
+        // Check for and set required server variables
+        if (!isset($_SERVER['PARTNER_ID'])) {
+            $this->markTestSkipped('PARTNER_ID is not available');
+        }
+        if (!isset($_SERVER['PARTNER_KEY'])) {
+            $this->markTestSkipped('PARTNER_KEY is not available');
+        }
+        $_SERVER['REMOTE_ADDR'] = getHostByName(getHostName());
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+
+        // Instantiate the connection
+        $config = new Config($_SERVER['PARTNER_ID'], $_SERVER['PARTNER_KEY']);
+        $connection = new Connection($config);
+
+        $action = new Company;
+        $action->addparam('query', 'google');
+
+        // Get the response from the API
+        $response = $connection->call($action);
+        
+        // Assert proper classes/results are returned
+        $this->assertEquals('Glassdoor\ResponseObject\Company\CompanyResponse', get_class($response));
+        foreach ($response->getCompanies() as $company) {
+            $this->assertEquals('Glassdoor\ResponseObject\Company\Company', get_class($company));
+            $this->assertNotNull($company->getId());
+        }
+    }
+
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -2,8 +2,22 @@
 
 namespace Glassdoor\Tests;
 
+use Glassdoor\Config;
 use Glassdoor\Connection;
 
 class ConnectionTest extends \PHPUnit_Framework_TestCase {
-  // Tests go here
+  
+    public function testItCanInstantiate()
+    {
+        $partner_id = 123;
+        $partner_key = 1234;
+        $base_url = 'http://google.com';
+        $config = new Config($partner_id, $partner_key, $base_url, 'json');
+        
+        // Mocking the config would be better, but this one's marked final
+        // $config = $this->getMockBuilder('Glassdoor\Config')->getMock();
+        
+        $connection = new Connection($config);
+    }
+
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Connection;
+
+class ConnectionTest extends \PHPUnit_Framework_TestCase {
+  // Tests go here
+}

--- a/tests/JobProgressionAcceptanceTest.php
+++ b/tests/JobProgressionAcceptanceTest.php
@@ -9,10 +9,10 @@ use Glassdoor\Connection;
 class JobProgressionAcceptanceTest extends \PHPUnit_Framework_TestCase {
   
     /* 
-     * Company Acceptance test 
+     * JobProgression Acceptance test 
      * Ensures the API client works end-to-end
      */
-    public function testItCanGetCompanyFromApiInRealLife()
+    public function testItCanGetJobProgressionFromApiInRealLife()
     {
         // Check for and set required server variables
         if (!isset($_SERVER['PARTNER_ID'])) {

--- a/tests/JobProgressionAcceptanceTest.php
+++ b/tests/JobProgressionAcceptanceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Glassdoor\Tests;
+
+use Glassdoor\Action\JobProgression;
+use Glassdoor\Config;
+use Glassdoor\Connection;
+
+class JobProgressionAcceptanceTest extends \PHPUnit_Framework_TestCase {
+  
+    /* 
+     * Company Acceptance test 
+     * Ensures the API client works end-to-end
+     */
+    public function testItCanGetCompanyFromApiInRealLife()
+    {
+        // Check for and set required server variables
+        if (!isset($_SERVER['PARTNER_ID'])) {
+            $this->markTestSkipped('PARTNER_ID is not available');
+        }
+        if (!isset($_SERVER['PARTNER_KEY'])) {
+            $this->markTestSkipped('PARTNER_KEY is not available');
+        }
+        $_SERVER['REMOTE_ADDR'] = getHostByName(getHostName());
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+
+        // Instantiate the connection
+        $config = new Config($_SERVER['PARTNER_ID'], $_SERVER['PARTNER_KEY']);
+        $connection = new Connection($config);
+
+        $action = new JobProgression;
+        $action->addparam('job_title', 'developer');
+
+        // Get the response from the API
+        $response = $connection->call($action);
+        
+        // Assert proper classes/results are returned
+        $this->assertEquals('Glassdoor\ResponseObject\JobProgressionResponse', get_class($response));
+        foreach ($response->getJobProgressions() as $progression) {
+            $this->assertEquals('Glassdoor\ResponseObject\JobProgression', get_class($progression));
+            $this->assertNotNull($progression->getJobTitle());
+        }
+    }
+
+}

--- a/tests/ResponseObject/Company/PersonTest.php
+++ b/tests/ResponseObject/Company/PersonTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Glassdoor\Tests\ResponseObject\Company;
+
+use Glassdoor\ResponseObject\Company\Person;
+
+class PersonTest extends \PHPUnit_Framework_TestCase {
+    
+    public function setUp()
+    {
+        $this->values = [
+            'name' => uniqid(),
+            'title' => uniqid(),
+            'percent_approval' => uniqid(),
+            'percent_disapproval' => uniqid(),
+            'image' => [
+                'src' => uniqid(),
+                'height' => uniqid(),
+                'width' => uniqid(),
+            ],
+        ];
+
+        $this->person = new Person($this->values);
+    }
+
+    public function testItCanInstantiateWithoutImage()
+    {
+        $values = $this->values;
+        $values['image'] = [];
+
+        $person = new Person($values);
+    }
+
+    public function testItGetsPersonName()
+    {
+        $result = $this->person->getName();
+        
+        $this->assertEquals($this->values['name'], $result);
+    }
+
+    public function testItGetsPersonTitle()
+    {
+        $result = $this->person->getTitle();
+        
+        $this->assertEquals($this->values['title'], $result);
+    }
+
+    public function testItGetsPersonPercentApproval()
+    {
+        $result = $this->person->getPercentApproval();
+        
+        $this->assertEquals($this->values['percent_approval'], $result);
+    }
+
+    public function testItGetsPersonPercentDisapproval()
+    {
+        $result = $this->person->getPercentDisapproval();
+        
+        $this->assertEquals($this->values['percent_disapproval'], $result);
+    }
+
+    public function testItGetsPersonImage()
+    {   
+        $result = $this->person->getImage();
+        
+        $this->assertEquals('Glassdoor\ResponseObject\Image', get_class($result));
+    }
+    
+}

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Glassdoor\Tests\ResponseObject;
+
+use Glassdoor\ResponseObject\Image;
+
+class ImageTest extends \PHPUnit_Framework_TestCase {
+    
+    public function setUp()
+    {
+        $this->values = [
+            'src' => uniqid(),
+            'height' => uniqid(),
+            'width' => uniqid(),
+            'weight' => uniqid(),
+        ];
+
+        $this->image = new Image($this->values);
+    }
+
+    /**
+     * @expectedException \Glassdoor\Error\GlassDoorResponseException
+     * @expectedExceptionMessage Image requires src, height and width
+     */
+    public function testItThrowsErrorWhenInvalidInputValues()
+    {
+        $values = [];
+        $image = new Image($values);
+    }
+
+    public function testItGetsImageSrc()
+    {
+        $result = $this->image->getSrc();
+        
+        $this->assertEquals($this->values['src'], $result);
+    }
+
+    public function testItGetsImageHeight()
+    {
+        $result = $this->image->getHeight();
+        
+        $this->assertEquals($this->values['height'], $result);
+    }
+
+    public function testItGetsImageWeight()
+    {
+        $result = $this->image->getWeight();
+        
+        $this->assertEquals($this->values['weight'], $result);
+    }
+    
+}

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -44,9 +44,9 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
 
     public function testItGetsImageWeight()
     {
-        $result = $this->image->getWeight();
-        
-        $this->assertEquals($this->values['weight'], $result);
+        // Not working, might be a bug.
+        // $result = $this->image->getWeight();
+        // $this->assertEquals($this->values['weight'], $result);
     }
     
 }

--- a/tests/ResponseObject/ImageTest.php
+++ b/tests/ResponseObject/ImageTest.php
@@ -12,7 +12,6 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
             'src' => uniqid(),
             'height' => uniqid(),
             'width' => uniqid(),
-            'weight' => uniqid(),
         ];
 
         $this->image = new Image($this->values);
@@ -42,11 +41,10 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($this->values['height'], $result);
     }
 
-    public function testItGetsImageWeight()
+    public function testItGetsImageWidth()
     {
-        // Not working, might be a bug.
-        // $result = $this->image->getWeight();
-        // $this->assertEquals($this->values['weight'], $result);
+        $result = $this->image->getWidth();
+        $this->assertEquals($this->values['width'], $result);
     }
     
 }


### PR DESCRIPTION
I added CodeSniffer to check against the Drupal code standards in the project. Right now, there are a ton of errors, so I set Travis to ignore them until we get that resolved. When they're all green, we can just remove the `./vendor/bin/phpcs --config-set ignore_errors_on_exit 1` bit from the travis config.

To run the code sniffer, just run `./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal src/`

References #8 